### PR TITLE
feat: add compability to idealista.pt/com/es/it...

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -141,7 +141,7 @@ function getScrapperOptionsByUrl(url: string, title: string): ScrapperOptions | 
     };
   }
 
-  if (url.includes('idealista.pt') && (url.includes('/comprar-') || url.includes('/arrendar-'))) {
+  if (url.includes('idealista.')) {
     return {
       header: 'Idealista search results',
       listElementsQuery: '.item',


### PR DESCRIPTION
### Related to

- Add idealista to the scrapper list (we don't have an issue system at this moment)

### Context

Currently, the current scrapper for idealista only works with the Portuguese domain, so after this commit, it will work with other domains like .es, .com, .it, .nl, etc.