### PR TITLE
release: 1.0.8

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,5 @@
 {
   "name": "RowsX",
-  "version": "1.0.7",
   "manifest_version": 3,
   "background": {
     "service_worker": "src/background.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rows-x",
   "private": true,
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,15 @@ import preact from '@preact/preset-vite';
 import { crx } from '@crxjs/vite-plugin';
 import viteYaml from '@modyfi/vite-plugin-yaml';
 import manifest from './manifest';
+import npmPackage from './package';
+
+const extensionManifest = {
+  version: npmPackage.version,
+  ...manifest,
+};
 
 const e2eTestManifest = {
-  ...manifest,
+  ...extensionManifest,
   host_permissions: ['<all_urls>'],
 };
 
@@ -14,7 +20,7 @@ export default defineConfig(({ mode }) => ({
     preact(),
     viteYaml(),
     crx({
-      manifest: mode === 'e2e' ? e2eTestManifest : manifest,
+      manifest: mode === 'e2e' ? e2eTestManifest : extensionManifest,
     }),
   ],
 }));


### PR DESCRIPTION
### Related to

Releasing the 1.0.8 version

### Context

- Now we could update the package version to update the manifest version.
- Added E2E tests
- Added new scrappers like:
	- g2.com reviews page
	- idealista.(multi-domain)
	- youtube.com  - history
	- craigslist.(multi-domain)
	- autotrader.com (USA)
	- kuantokusta (single product and search)
	- homes.com
	- redfin.com
	- bug fix zillow.com