### PR TITLE
ci: change the github actions to run on ubuntu

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on: workflow_dispatch
 jobs:
   test:
     name: E2E Tests
-    runs-on: rows-fe-4core
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout code
@@ -25,7 +25,7 @@ jobs:
   build-and-deploy-extension:
     name: Build & deploy extension
     needs: test
-    runs-on: rows-fe-default
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   audit:
     name: Audit dependencies
-    runs-on: rows-fe-default
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -19,7 +19,7 @@ jobs:
 
   static-analysis:
     name: Static analysis
-    runs-on: rows-fe-4core
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout code
@@ -42,7 +42,7 @@ jobs:
 
   test:
     name: E2E Tests
-    runs-on: rows-fe-4core
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   audit:
     name: Audit dependencies
-    runs-on: rows-fe-default
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -20,7 +20,7 @@ jobs:
 
   static-analysis:
     name: Static analysis
-    runs-on: rows-fe-4core
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -43,7 +43,7 @@ jobs:
   create-release:
     name: Create release
     needs: [static-analysis]
-    runs-on: rows-fe-default
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
### Related to

N/A

### Context

In public repositories, it's not possible to run self-hosted actions.

### Approach

Replace the usage of self-hosted runners with the GitHub-hosted runners.
