### PR TITLE
feat: add scrapper to new sites

### DIFF
--- a/src/scrappers/babyone.yml
+++ b/src/scrappers/babyone.yml
@@ -1,0 +1,20 @@
+url: 
+  - https://www.babyone.de/*
+listElementsQuery: .product-box
+elementParser:
+
+  - title: Item Description
+    query: .product-name
+    type: text
+
+  - title: Item brand
+    query: .product-brand
+    type: text
+  
+  - title: RRP
+    query: .list-price
+    type: text
+  
+  - title: Price
+    query: .sale-price
+    type: text

--- a/src/scrappers/bebe9.yml
+++ b/src/scrappers/bebe9.yml
@@ -1,0 +1,20 @@
+url: 
+  - https://www.bebe9.com/*
+listElementsQuery: '.products-list > article'
+elementParser:
+
+  - title: Item Description
+    query: .product-name
+    type: text
+
+  - title: Item brand
+    query: .product-brand
+    type: text
+  
+  - title: RRP
+    query: .product-public-sale-price
+    type: text
+  
+  - title: Price
+    query: .product-price
+    type: text

--- a/src/scrappers/bol.yml
+++ b/src/scrappers/bol.yml
@@ -1,0 +1,20 @@
+url: 
+  - https://www.bol.com/*
+listElementsQuery: .product-item, .product-item--row
+elementParser:
+
+  - title: Item Description
+    query: .product-title
+    type: text
+
+  - title: Brand
+    query: '[itemprop="name"]'
+    type: text
+  
+  - title: RRP
+    query: '[data-test="list-price"], [data-test="from-price"]'
+    type: text
+
+  - title: Price
+    query: .promo-price
+    type: text

--- a/src/scrappers/cdiscount.yml
+++ b/src/scrappers/cdiscount.yml
@@ -1,0 +1,16 @@
+url: 
+  - https://www.cdiscount.com/*
+listElementsQuery: '[data-cs-override-id="Offres-LP"] > li'
+elementParser:
+
+  - title: Item Description
+    query: h2
+    type: text
+  
+  - title: RRP
+    query: '.c-price-s > s'
+    type: text
+  
+  - title: Price
+    query: .c-price
+    type: text

--- a/src/scrappers/dreambaby.yml
+++ b/src/scrappers/dreambaby.yml
@@ -1,0 +1,12 @@
+url: 
+  - https://www.dreambaby.be/*
+listElementsQuery: '[data-name="Product"]'
+elementParser:
+
+  - title: Item Description
+    query: 'h3'
+    type: text
+  
+  - title: Price
+    query: '[itemprop="price"]'
+    type: text

--- a/src/scrappers/johnlewis.yml
+++ b/src/scrappers/johnlewis.yml
@@ -1,0 +1,20 @@
+url: 
+  - https://www.johnlewis.com/*
+listElementsQuery: article
+elementParser:
+
+  - title: Item Description
+    query: '[data-test="product-title"] > h2 > span:nth-child(2)'
+    type: text
+
+  - title: Item brand
+    query: '[data-test="product-title"] > h2 > span:nth-child(1)'
+    type: text
+  
+  - title: RRP
+    query: '[data-test="product-card-price-prev"]'
+    type: text
+  
+  - title: Price
+    query: '[data-test="product-card-price-now"]'
+    type: text

--- a/src/scrappers/jollyroom.yml
+++ b/src/scrappers/jollyroom.yml
@@ -1,0 +1,16 @@
+url: 
+  - https://www.jollyroom.se/*
+listElementsQuery: '.product-info'
+elementParser:
+
+  - title: Item Description
+    query: h3
+    type: text
+  
+  - title: RRP
+    query: .recommmended-price
+    type: text
+  
+  - title: Price
+    query: .price
+    type: text


### PR DESCRIPTION
Add scrapper to the following websites
-  babyone.de
- bebe9.com
- cdiscount.com
- johnlewis.com
- dreambaby.be
- bol.com/nl/nl
- jollyroom.se


  