### PR TITLE
fix: fix URL matching scrappers

### DIFF
--- a/src/scrappers/babymarket-list-products.yml
+++ b/src/scrappers/babymarket-list-products.yml
@@ -1,13 +1,5 @@
 url: 
-  - https://www.babymarkt.de/search/*
-  - https://www.babymarkt.de/unterwegs/*
-  - https://www.babymarkt.de/kindersitze/*
-  - https://www.babymarkt.de/pflegeprodukte/*
-  - https://www.babymarkt.de/ernaehrung/*
-  - https://www.babymarkt.de/kinderzimmer/*
-  - https://www.babymarkt.de/spielzeug/*
-  - https://www.babymarkt.de/mode/*
-  - https://www.babymarkt.de/sale/*
+  - https://www.babymarkt.de/*/*
 listElementsQuery: '.products__item'
 elementParser:
   - title: Item Brand

--- a/src/scrappers/pinkorblue-list-products-it.yml
+++ b/src/scrappers/pinkorblue-list-products-it.yml
@@ -1,13 +1,5 @@
 url: 
-  - https://www.pinkorblue.it/search/*
-  - https://www.pinkorblue.it/passeggini/*
-  - https://www.pinkorblue.it/seggiolini-auto/*
-  - https://www.pinkorblue.it/igiene/*
-  - https://www.pinkorblue.it/alimentazione/*
-  - https://www.pinkorblue.it/camerette/*
-  - https://www.pinkorblue.it/giochi/*
-  - https://www.pinkorblue.it/moda/*
-  - https://www.pinkorblue.it/saldi/*
+  - https://www.pinkorblue.it/*/*
 listElementsQuery: .products__item
 elementParser:
   - title: Item Brand

--- a/src/scrappers/pinkorblue-list-products-nl.yml
+++ b/src/scrappers/pinkorblue-list-products-nl.yml
@@ -1,13 +1,5 @@
 url: 
-  - https://www.pinkorblue.nl/search/*
-  - https://www.pinkorblue.nl/kinderwagens/*
-  - https://www.pinkorblue.nl/autostoelen/*
-  - https://www.pinkorblue.nl/verzorging/*
-  - https://www.pinkorblue.nl/voeding/*
-  - https://www.pinkorblue.nl/kinderkamer/*
-  - https://www.pinkorblue.nl/speelgoed/*
-  - https://www.pinkorblue.nl/mode/*
-  - https://www.pinkorblue.nl/outlet/*
+  - https://www.pinkorblue.nl/*/*
 listElementsQuery: .products__item
 elementParser:
   - title: Item Brand

--- a/src/scrappers/pinkorblue-list-products.yml
+++ b/src/scrappers/pinkorblue-list-products.yml
@@ -1,12 +1,5 @@
 url: 
-  - https://www.pinkorblue.be/search/*
-  - https://www.pinkorblue.be/kinderwagens/*
-  - https://www.pinkorblue.be/autostoelen/*
-  - https://www.pinkorblue.be/verzorging/*
-  - https://www.pinkorblue.be/kinderkamer/*
-  - https://www.pinkorblue.be/speelgoed/*
-  - https://www.pinkorblue.be/mode/*
-  - https://www.pinkorblue.be/outlet/*
+  - https://www.pinkorblue.be/*/*
 listElementsQuery: .products__item
 elementParser:
   - title: Item Brand


### PR DESCRIPTION
The URL pattern matching wasn't working as expected. The problem was fixed within the scope of this [PR](https://github.com/rows/X/pull/92).

Now that the matching is working as expected, the goal is to remove all the unnecessary URLs patterns from the scrapper configuration files.