### PR TITLE
fix: start reporting the usage when the user selects Open in Rows

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { ERROR_MESSAGES, ErrorCodes } from './error-codes';
 import { getCurrentTab, runScrapper } from './utils/chrome';
+import { reportUsage } from './utils/rows-api/report';
 import { getScrapperOptionsByUrl } from './utils/scrapperUtils';
 
 async function scrap() {
@@ -39,7 +40,7 @@ chrome.runtime.onMessage.addListener((message, _, sendResponse) => {
       break;
     case 'rows-x:store':
       chrome.tabs.create({ url: 'https://rows.com/new' }, (tab) => {
-        return storeRowsXData(message.data, tab.id!);
+        return storeRowsXData(message.data, tab.id!).then(() => reportUsage({action: 'open_in_Rows'}));
       });
       break;
     default:

--- a/src/components/preview.tsx
+++ b/src/components/preview.tsx
@@ -15,9 +15,6 @@ const Preview: FunctionComponent<Props> = ({ results = [] }) => {
       await chrome.runtime.sendMessage({
         action: 'rows-x:store',
         data: array2tsv(table),
-      }).then(() => {
-        // Send usage report
-        reportUsage({action: 'open_in_Rows'});
       });
     } catch (error) {
       console.error("Failed to open data in Rows:", error);


### PR DESCRIPTION
Related to https://github.com/rows/X/pull/101

The extension isn't reporting the usage when the user selects the `Open in Rows` option. This PR intends to fix that.