### PR TITLE
fix(usage-metrics): correctly report the current tab URL when `Opening in Rows`

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -23,6 +23,20 @@ async function scrap() {
   return await runScrapper(tab, options);
 }
 
+async function openInRows(message: { data: string; }) {
+  const tab = await getCurrentTab();
+
+  if (!tab || !tab.url || !tab.title) {
+    return;
+  }
+
+  const tabUrl = tab.url;
+
+  chrome.tabs.create({ url: 'https://rows.com/new' }, (tab) => {
+    return storeRowsXData(message.data, tab.id!).then(() => reportUsage({ action: 'open_in_Rows', url: tabUrl }));
+  });
+}
+
 async function storeRowsXData(tsv: string, tabId: number) {
   await chrome.scripting.executeScript({
     target: { tabId },
@@ -34,14 +48,13 @@ async function storeRowsXData(tsv: string, tabId: number) {
 }
 
 chrome.runtime.onMessage.addListener((message, _, sendResponse) => {
+  const tab = getCurrentTab();
   switch (message.action) {
     case 'rows-x:scrap':
       scrap().then((data) => sendResponse(data));
       break;
     case 'rows-x:store':
-      chrome.tabs.create({ url: 'https://rows.com/new' }, (tab) => {
-        return storeRowsXData(message.data, tab.id!).then(() => reportUsage({action: 'open_in_Rows'}));
-      });
+      openInRows(message);
       break;
     default:
       break;

--- a/src/background.ts
+++ b/src/background.ts
@@ -48,7 +48,6 @@ async function storeRowsXData(tsv: string, tabId: number) {
 }
 
 chrome.runtime.onMessage.addListener((message, _, sendResponse) => {
-  const tab = getCurrentTab();
   switch (message.action) {
     case 'rows-x:scrap':
       scrap().then((data) => sendResponse(data));

--- a/src/utils/rows-api/report.ts
+++ b/src/utils/rows-api/report.ts
@@ -4,6 +4,7 @@ import UAParser from 'ua-parser-js';
 
 interface ReportUsageParams {
   action: 'copy_values' | 'open_in_Rows';
+  url?: string;
 }
 
 export async function createNewReportEntryRow(feedback? : string) {
@@ -42,8 +43,8 @@ export async function reportUsage(params: ReportUsageParams): Promise<void> {
 
   const row_cells = [
     new Date(),
-    tab.url,
-    new URL(tab.url!).hostname,
+    params.url ? params.url : tab.url,
+    new URL(params.url ? params.url : tab.url!).hostname,
     userAgent.getBrowser().name,
     userAgent.getBrowser().version,
     action,


### PR DESCRIPTION
The URL field on the usage report metric reported when Opening in Rows is wrongly reported. It's reporting the `https://rows.new` URL.

This PR intends to correctly report the original tab URL.